### PR TITLE
Allow multiple guesses per user

### DIFF
--- a/convex/game.ts
+++ b/convex/game.ts
@@ -60,9 +60,8 @@ export const set = mutationWithUser({
 		won: v.boolean(),
 		wordOfTheDay: v.optional(v.string()),
 		aboutWord: v.optional(v.string()),
-		submittedUsers: v.optional(v.array(v.string())),
-		trashTalk: v.optional(v.string()),
-	},
+                trashTalk: v.optional(v.string()),
+        },
 	handler: async (ctx, args) => {
 		const { _id, ...gameData } = args
 		if (!_id) {
@@ -87,10 +86,9 @@ export const createGame = internalMutation({
 			won: false,
 			wordOfTheDay: undefined,
 			aboutWord: undefined,
-			submittedUsers: [],
-		}
-		return await ctx.db.insert('game', game)
-	},
+                }
+                return await ctx.db.insert('game', game)
+        },
 })
 
 export const createNewGame = actionWithUser({
@@ -121,8 +119,7 @@ export const verifyGuess = mutationWithUser({
 			v.literal('loss'),
 			v.literal('invalid_word'),
 			v.literal('error'),
-			v.literal('already_submitted'),
-		),
+                ),
 		message: v.optional(v.string()),
 		gameFinished: v.optional(v.boolean()),
 		newRow: v.optional(v.any()),
@@ -154,15 +151,6 @@ export const verifyGuess = mutationWithUser({
 			return {
 				status: 'error' as const,
 				message: 'No game data found',
-			}
-		}
-
-		// Check if the user has already submitted a guess
-		const submittedUsers = gameData.submittedUsers || []
-		if (submittedUsers.includes(userSubject)) {
-			return {
-				status: 'already_submitted' as const,
-				message: 'You have already submitted a guess today!',
 			}
 		}
 
@@ -216,8 +204,7 @@ export const verifyGuess = mutationWithUser({
 			won: isWin,
 			wordOfTheDay: gameFinished ? secretWord : gameData.wordOfTheDay,
 			aboutWord: gameFinished ? aboutWord : gameData.aboutWord,
-			submittedUsers: [...submittedUsers, userSubject], // Add the current user to submittedUsers
-		}
+                }
 
 		updatedGameData.data[rowIndex] = newRow
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -141,21 +141,31 @@ export const verifyGuess = mutationWithUser({
 		// Get the current game date from the server
 		const date = await getCurrentGameDate(ctx.db)
 
-		// 3. Get current game data
-		const gameData = await ctx.db
-			.query('game')
-			.withIndex('by_date', (q) => q.eq('date', date))
-			.first()
+                // 3. Get current game data
+                const gameData = await ctx.db
+                        .query('game')
+                        .withIndex('by_date', (q) => q.eq('date', date))
+                        .first()
 
-		if (!gameData) {
-			return {
-				status: 'error' as const,
-				message: 'No game data found',
-			}
-		}
+                if (!gameData) {
+                        return {
+                                status: 'error' as const,
+                                message: 'No game data found',
+                        }
+                }
 
-		// 1. Validate the word exists in our word list
-		if (guess.length !== NUMBER_OF_LETTERS) {
+                if (gameData.finished) {
+                        return {
+                                status: gameData.won ? ('win' as const) : ('loss' as const),
+                                gameFinished: true,
+                                word: gameData.wordOfTheDay ?? undefined,
+                                aboutWord: gameData.aboutWord ?? undefined,
+                                message: 'Game already finished',
+                        }
+                }
+
+                // 1. Validate the word exists in our word list
+                if (guess.length !== NUMBER_OF_LETTERS) {
 			return {
 				status: 'invalid_word' as const,
 				message: `Word must be ${NUMBER_OF_LETTERS} letters long`,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -40,9 +40,10 @@ export default defineSchema({
 		}),
 		finished: v.boolean(),
 		attempts: v.number(),
-		won: v.boolean(),
-		wordOfTheDay: v.optional(v.string()),
-		aboutWord: v.optional(v.string()),
+                won: v.boolean(),
+                wordOfTheDay: v.optional(v.string()),
+                aboutWord: v.optional(v.string()),
+                submittedUsers: v.optional(v.array(v.string())),
                 trashTalk: v.optional(v.string()),
         }).index('by_date', ['date']),
 	winners: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,9 +43,8 @@ export default defineSchema({
 		won: v.boolean(),
 		wordOfTheDay: v.optional(v.string()),
 		aboutWord: v.optional(v.string()),
-		submittedUsers: v.optional(v.array(v.string())),
-		trashTalk: v.optional(v.string()),
-	}).index('by_date', ['date']),
+                trashTalk: v.optional(v.string()),
+        }).index('by_date', ['date']),
 	winners: defineTable({
 		date: v.string(),
 		word: v.string(),

--- a/pages/game.tsx
+++ b/pages/game.tsx
@@ -86,16 +86,14 @@ const GamePage = () => {
 					{},
 					{
 						...args,
-						_id: currentGameData._id,
-						_creationTime: currentGameData._creationTime,
-						aboutWord: args.aboutWord ?? currentGameData.aboutWord,
-						submittedUsers:
-							args.submittedUsers ?? currentGameData.submittedUsers,
-					},
-				)
-			}
-		},
-	)
+                                                _id: currentGameData._id,
+                                                _creationTime: currentGameData._creationTime,
+                                                aboutWord: args.aboutWord ?? currentGameData.aboutWord,
+                                        },
+                                )
+                        }
+                },
+        )
 
 	const { user } = useUser()
 
@@ -229,14 +227,10 @@ const GamePage = () => {
 		)
 	}
 
-	// Check if the current user has already submitted a guess
-	const currentUserHasSubmitted =
-		(user?.id && gameData.submittedUsers?.includes(user.id)) || false
-
-	const handleNewCharacter = async (key: string) => {
-		if (!gameData || gameData.finished || currentUserHasSubmitted) {
-			return
-		}
+        const handleNewCharacter = async (key: string) => {
+                if (!gameData || gameData.finished) {
+                        return
+                }
 
 		const row = gameData.data[gameData.cursor.y]
 		const tile = row[gameData.cursor.x]
@@ -263,10 +257,10 @@ const GamePage = () => {
 		return await setGameData(updatedGameData)
 	}
 
-	const handleDeleteCharacter = async () => {
-		if (!gameData || currentUserHasSubmitted) {
-			return
-		}
+        const handleDeleteCharacter = async () => {
+                if (!gameData) {
+                        return
+                }
 
 		const lastNonEmptyTile = findLastNonEmptyTile(
 			gameData.data[gameData.cursor.y],
@@ -293,11 +287,6 @@ const GamePage = () => {
 
 	const handleEnter = async () => {
 		if (!gameData) {
-			return { status: 'playing', word: undefined }
-		}
-
-		// Check if the current user has already submitted a guess
-		if (currentUserHasSubmitted) {
 			return { status: 'playing', word: undefined }
 		}
 
@@ -332,18 +321,6 @@ const GamePage = () => {
 				return { status: 'playing', word: undefined }
 			}
 
-			if (result.status === 'already_submitted') {
-				toast.error(
-					result.message ||
-						`You have already submitted a guess for the ${formattedDate} puzzle!`,
-					{
-						icon: '🚫',
-						style: { borderRadius: '10px', background: '#333', color: '#fff' },
-					},
-				)
-				return { status: 'playing', word: undefined }
-			}
-
 			// Update game data with the results from server
 			if (result.newRow) {
 				const updatedGameData = structuredClone(gameData)
@@ -357,14 +334,8 @@ const GamePage = () => {
 				updatedGameData.won = result.status === 'win'
 				updatedGameData.wordOfTheDay = result.word
 				updatedGameData.aboutWord = result.aboutWord
-				// Ensure submittedUsers is updated in the local state
-				updatedGameData.submittedUsers = [
-					...(gameData.submittedUsers || []),
-					user?.id!,
-				]
-
-				await setGameData(updatedGameData)
-			}
+                                await setGameData(updatedGameData)
+                        }
 
 			return {
 				status: result.status,
@@ -382,15 +353,10 @@ const GamePage = () => {
 		}
 	}
 
-	const handleKeyPress = async (key: string) => {
-		// If current user has already submitted, don't allow any more interactions
-		if (currentUserHasSubmitted && !gameData.finished) {
-			return
-		}
-
-		if (!isMappableKey(key)) {
-			return await handleNewCharacter(key)
-		}
+        const handleKeyPress = async (key: string) => {
+                if (!isMappableKey(key)) {
+                        return await handleNewCharacter(key)
+                }
 
 		switch (key) {
 			case 'backspace':
@@ -565,36 +531,7 @@ const GamePage = () => {
 					</motion.div>
 				)}
 
-				{/* User already submitted message */}
-				{!gameData.finished && currentUserHasSubmitted && (
-					<motion.div
-						initial={{ opacity: 0, y: -20 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-						className='mb-6 px-6 py-5 rounded-xl shadow-lg text-center bg-gradient-to-br from-amber-50/90 to-orange-50/90 dark:from-zinc-800/90 dark:to-zinc-900/90 border border-brand-orange/20 dark:border-brand-orange/20 backdrop-blur-sm'
-					>
-						<div className='flex flex-col items-center'>
-							<h3 className='text-xl font-bold text-brand-orange mb-3 drop-shadow-sm'>
-								Your Guess is Locked In
-							</h3>
-
-							<p className='text-zinc-700 dark:text-zinc-300 max-w-md mb-3 leading-relaxed'>
-								You've made your contribution for the {formattedDate} puzzle.
-								Now it's time for others to join the challenge!
-							</p>
-
-							{gameData.trashTalk && (
-								<div className='mt-2 p-3 bg-white/50 dark:bg-zinc-800/50 rounded-lg border border-brand-orange/10 dark:border-brand-orange/10 max-w-md backdrop-blur-sm'>
-									<p className='text-sm italic text-brand-orange'>
-										"{gameData.trashTalk}"
-									</p>
-								</div>
-							)}
-						</div>
-					</motion.div>
-				)}
-
-				{/* Game state message */}
+                                {/* Game state message */}
 				{gameData.finished && (
 					<motion.div
 						initial={{ opacity: 0, scale: 0.9 }}
@@ -662,13 +599,13 @@ const GamePage = () => {
 								your keyboard to type
 							</p>
 						</div>
-						<Keyboard
-							onKeyPress={handleKeyPress}
-							usedKeys={usedKeys}
-							disabled={gameData.finished || currentUserHasSubmitted}
-						/>
-					</motion.div>
-				</div>
+                                                <Keyboard
+                                                        onKeyPress={handleKeyPress}
+                                                        usedKeys={usedKeys}
+                                                        disabled={gameData.finished}
+                                                />
+                                        </motion.div>
+                                </div>
 			</div>
 		</Page>
 	)


### PR DESCRIPTION
## Summary
- remove the submitted user tracking fields and server-side check so the backend no longer enforces a single guess per player
- update the game page so the keyboard and grid remain interactive after each guess and remove the locked-in message
